### PR TITLE
Text Formatting | Add Space for Nice Job Messages

### DIFF
--- a/helpers/scheduled_jobs.js
+++ b/helpers/scheduled_jobs.js
@@ -84,7 +84,7 @@ const onCronTick = async function (reminderConfig) {
         if (messagesFilteredForConfig.length === 0) {
           await client.chat.postMessage({
             channel: channel.id,
-            text: `:tada: Nice job, <#${channel.id}>!` +
+            text: `:tada: Nice job, <#${channel.id}>! ` +
               `There are ${messagesFilteredForConfig.length} messages from the past ${reminderConfig.hours_to_look_back} hours that are ` +
               `either ${levelEmojis.join(
                 '/'


### PR DESCRIPTION
###  Summary

This is a small nit to fix a formatting issue where there wasn't a space between the `Nice job` message and the description of the remaining issues. It's been bothering me for the past couple of years 😅 

![Screen Shot 2024-02-15 at 2 28 37 PM](https://github.com/slackapi/template-triage-bot/assets/8298272/864aba7d-4471-427c-83ea-ec0e7a424b96)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](../CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).